### PR TITLE
Chunkmap Consistency + State Output Feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,40 @@
-# Project exclude paths
-/.gradle/
-# Project exclude paths
-/build/
+# gradle
+
+.gradle/
+build/
+out/
+classes/
+
+# eclipse
+
+*.launch
+
+# idea
+
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# vscode
+
+.settings/
+.vscode/
+bin/
+.classpath
+.project
+
+# macos
+
+*.DS_Store
+
+# fabric
+
+run/
+
+# java
+
+hs_err_*.log
+replay_*.log
+*.hprof
+*.jfr

--- a/src/main/java/me/voidxwalker/worldpreview/StateOutputHelper.java
+++ b/src/main/java/me/voidxwalker/worldpreview/StateOutputHelper.java
@@ -1,0 +1,51 @@
+package me.voidxwalker.worldpreview;
+
+import org.apache.logging.log4j.Level;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A helper class for outputting the state to help macros handle Minecraft without
+ */
+public final class StateOutputHelper {
+    private static final Path OUT_PATH = Path.of("wpstateout.txt");
+    private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
+    // Storage variable, not necessarily involved or required for using outputState()
+    public static int loadingProgress = 0;
+    public static boolean titleHasEverLoaded = false;
+    private static String lastOutput = "";
+
+
+    private StateOutputHelper() {
+    }
+
+    public static void outputState(String string) {
+        // Prevent "generating,0" from appearing on game start
+        if (!titleHasEverLoaded) {
+            if (string.equals("title")) titleHasEverLoaded = true;
+            else return;
+        }
+
+        // Check for changes
+        if (lastOutput.equals(string)) {
+            return;
+        }
+        lastOutput = string;
+
+        // Queue up the file writes as to not interrupt mc itself
+        EXECUTOR.execute(() -> outputStateInternal(string));
+    }
+
+    private static void outputStateInternal(String string) {
+        try {
+            // Java 11+ method
+            Files.writeString(OUT_PATH, string);
+        } catch (IOException ignored) {
+            WorldPreview.log(Level.ERROR, "Failed to write state output!");
+        }
+    }
+}

--- a/src/main/java/me/voidxwalker/worldpreview/StateOutputHelper.java
+++ b/src/main/java/me/voidxwalker/worldpreview/StateOutputHelper.java
@@ -44,6 +44,7 @@ public final class StateOutputHelper {
         try {
             // Java 11+ method
             Files.writeString(OUT_PATH, string);
+            WorldPreview.log(Level.INFO, "WorldPreview State: " + string);
         } catch (IOException ignored) {
             WorldPreview.log(Level.ERROR, "Failed to write state output!");
         }

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/MinecraftClientMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/MinecraftClientMixin.java
@@ -1,12 +1,14 @@
 package me.voidxwalker.worldpreview.mixin.client;
 
 import me.voidxwalker.worldpreview.OldSodiumCompatibility;
+import me.voidxwalker.worldpreview.StateOutputHelper;
 import me.voidxwalker.worldpreview.WorldPreview;
 import me.voidxwalker.worldpreview.mixin.access.WorldRendererMixin;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.screen.LevelLoadingScreen;
 import net.minecraft.client.gui.screen.Screen;
 import net.minecraft.client.gui.screen.TitleScreen;
+import net.minecraft.client.network.ClientPlayerEntity;
 import net.minecraft.client.render.BufferBuilderStorage;
 import net.minecraft.client.render.WorldRenderer;
 import net.minecraft.client.world.ClientWorld;
@@ -32,6 +34,7 @@ public abstract class MinecraftClientMixin {
 
     @Shadow private @Nullable IntegratedServer server;
 
+    @Shadow @Nullable public ClientPlayerEntity player;
     @Shadow @Nullable public ClientWorld world;
     @Shadow @Nullable public Screen currentScreen;
 
@@ -113,6 +116,30 @@ public abstract class MinecraftClientMixin {
                 ((OldSodiumCompatibility)WorldPreview.worldRenderer).worldpreview_setWorldSafe(null);
             }
             worldpreview_cycleCooldown=0;
+        }
+    }
+
+    @Inject(method = "disconnect(Lnet/minecraft/client/gui/screen/Screen;)V", at = @At("TAIL"))
+    private void worldpreview_outputWaitingState(Screen screen, CallbackInfo info) {
+        // We do this inject after this.player is set to null in the disconnect method.
+        // This is because the inworld state output depends on the player being non-null,
+        // so it makes more sense to set the state for exiting after the player becomes null.
+
+        // While disconnect is intended for leaving a world, it may also occur before the first world creation,
+        // hence the output "waiting" as opposed to "exiting"
+        StateOutputHelper.outputState("waiting");
+    }
+
+    @Inject(method = "tick", at = @At("TAIL"))
+    private void worldpreview_outputInWorldState(CallbackInfo info) {
+        // If there is no player, there is no world to be in
+        if (this.player == null) return;
+        if (this.currentScreen == null) {
+            StateOutputHelper.outputState("inworld,unpaused");
+        } else if (this.currentScreen.isPauseScreen()) {
+            StateOutputHelper.outputState("inworld,paused");
+        } else {
+            StateOutputHelper.outputState("inworld,gamescreenopen");
         }
     }
 }

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/TitleScreenMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/TitleScreenMixin.java
@@ -1,0 +1,21 @@
+package me.voidxwalker.worldpreview.mixin.client;
+
+import me.voidxwalker.worldpreview.StateOutputHelper;
+import net.minecraft.client.gui.screen.TitleScreen;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * This mixin is to state output when the title screen loads.
+ */
+@Mixin(TitleScreen.class)
+public abstract class TitleScreenMixin {
+
+    // We inject into the first tick rather than the tail of init because the tail of init will still load even if Atum is resetting.
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void worldpreview_outputTitleState(CallbackInfo ci) {
+        StateOutputHelper.outputState("title");
+    }
+}

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/WorldGenerationProgressLoggerMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/WorldGenerationProgressLoggerMixin.java
@@ -1,0 +1,26 @@
+package me.voidxwalker.worldpreview.mixin.client;
+
+import me.voidxwalker.worldpreview.StateOutputHelper;
+import me.voidxwalker.worldpreview.WorldPreview;
+import net.minecraft.server.WorldGenerationProgressLogger;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.MathHelper;
+import net.minecraft.world.chunk.ChunkStatus;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(WorldGenerationProgressLogger.class)
+public abstract class WorldGenerationProgressLoggerMixin {
+    @Inject(method = "setChunkStatus", at = @At(value = "INVOKE", target = "Lorg/apache/logging/log4j/Logger;info(Ljava/lang/String;)V", shift = At.Shift.BEFORE))
+    private void worldpreview_outputGenerationState(ChunkPos pos, ChunkStatus status, CallbackInfo info) {
+        // Using the getProgressPercentage to recalculate is slightly unoptimized but prevents needing to do locals capture, making it easier to port this mixin.
+        StateOutputHelper.loadingProgress = MathHelper.clamp(getProgressPercentage(), 0, 100);
+        StateOutputHelper.outputState((WorldPreview.inPreview ? "previewing," : "generating,") + StateOutputHelper.loadingProgress);
+    }
+
+    @Shadow
+    public abstract int getProgressPercentage();
+}

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/LevelLoadingScreenMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/LevelLoadingScreenMixin.java
@@ -2,6 +2,7 @@ package me.voidxwalker.worldpreview.mixin.client.render;
 
 import com.mojang.blaze3d.systems.RenderSystem;
 import me.voidxwalker.worldpreview.OldSodiumCompatibility;
+import me.voidxwalker.worldpreview.StateOutputHelper;
 import me.voidxwalker.worldpreview.WorldPreview;
 import me.voidxwalker.worldpreview.mixin.access.WorldRendererMixin;
 import net.minecraft.client.MinecraftClient;
@@ -42,6 +43,8 @@ public abstract class LevelLoadingScreenMixin extends Screen {
         WorldPreview.calculatedSpawn=true;
         WorldPreview.freezePreview=false;
         KeyBinding.unpressAll();
+        StateOutputHelper.loadingProgress = 0;
+        StateOutputHelper.outputState("generating,0");
     }
     @Redirect(method = "render",at = @At(value = "INVOKE",target = "Lnet/minecraft/client/gui/screen/LevelLoadingScreen;renderBackground(Lnet/minecraft/client/util/math/MatrixStack;)V"))
     public void worldpreview_stopBackgroundRender(LevelLoadingScreen instance, MatrixStack matrixStack){
@@ -86,6 +89,7 @@ public abstract class LevelLoadingScreenMixin extends Screen {
                     WorldPreview.camera.update(WorldPreview.world, WorldPreview.player, this.client.options.perspective > 0, this.client.options.perspective == 2, 0.2F);
                     WorldPreview.player.refreshPositionAndAngles(WorldPreview.player.getX(), WorldPreview.player.getY() - 1.5, WorldPreview.player.getZ(), 0.0F, 0.0F);
                     WorldPreview.inPreview=true;
+                    StateOutputHelper.outputState("previewing," + StateOutputHelper.loadingProgress);
                     WorldPreview.log(Level.INFO,"Starting Preview at ("+ WorldPreview.player.getX() + ", "+(double)Math.floor(WorldPreview.player.getY())+ ", "+ WorldPreview.player.getZ()+")");
                 }
                 MatrixStack matrixStack = new MatrixStack();

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/LevelLoadingScreenMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/LevelLoadingScreenMixin.java
@@ -51,17 +51,11 @@ public abstract class LevelLoadingScreenMixin extends Screen {
     }
     @ModifyVariable(method = "render", at = @At("STORE"), ordinal = 2)
     public int worldpreview_moveLoadingScreen(int i){
-        if(WorldPreview.camera==null){
-            return i;
-        }
         return worldpreview_getChunkMapPos().x;
     }
 
     @ModifyVariable(method = "render", at = @At("STORE"), ordinal = 3)
     public int moveLoadingScreen2(int i){
-        if(WorldPreview.camera==null){
-            return i;
-        }
         return worldpreview_getChunkMapPos().y;
     }
     @Inject(method = "render",at=@At("HEAD"))

--- a/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/chunk/ChunkBuilderMixin.java
+++ b/src/main/java/me/voidxwalker/worldpreview/mixin/client/render/chunk/ChunkBuilderMixin.java
@@ -33,10 +33,8 @@ public class ChunkBuilderMixin {
     @Inject(method = "<init>", at = @At(value = "TAIL"))
     public void worldpreview_sodiumCompatibility(World world, WorldRenderer worldRenderer, Executor executor, boolean is64Bits, BlockBufferBuilderStorage buffers, CallbackInfo ci) {
         if(MinecraftClient.getInstance().currentScreen instanceof LevelLoadingScreen) {
-            int i = Math.max(1, (int) ((double) Runtime.getRuntime().maxMemory() * 0.3D) / (RenderLayer.getBlockLayers().stream().mapToInt(RenderLayer::getExpectedBufferSize).sum() * 4) - 1);
-            int j = Runtime.getRuntime().availableProcessors();
-            int k = is64Bits ? j : Math.min(j, 4);
-            int l = Math.max(1, Math.min(k, i));
+            // Override vanilla logic because 1 buffer thread is just better for multi instance, faster world gen and less memory usage (Author @jojoe77777)
+            int l = 1;
             ArrayList list = this.worldpreview_getList(l);
             try {
                 for (int m = 0; m < l; ++m) {

--- a/src/main/resources/worldpreview.mixins.json
+++ b/src/main/resources/worldpreview.mixins.json
@@ -21,6 +21,8 @@
     "client.render.chunk.BuiltChunkMixin",
     "client.render.LevelLoadingScreenMixin",
     "client.render.WorldRendererMixin",
+    "client.TitleScreenMixin",
+    "client.WorldGenerationProgressLoggerMixin",
 
     "client.MinecraftClientMixin",
     "client.KeyboardMixin",

--- a/src/main/resources/worldpreview.mixins.json
+++ b/src/main/resources/worldpreview.mixins.json
@@ -21,13 +21,13 @@
     "client.render.chunk.BuiltChunkMixin",
     "client.render.LevelLoadingScreenMixin",
     "client.render.WorldRendererMixin",
-    "client.TitleScreenMixin",
-    "client.WorldGenerationProgressLoggerMixin",
 
     "client.MinecraftClientMixin",
     "client.KeyboardMixin",
     "client.GameOptionsMixin",
     "client.ClientWorldMixin",
+    "client.TitleScreenMixin",
+    "client.WorldGenerationProgressLoggerMixin",
 
     "server.MinecraftServerMixin",
     "server.ServerChunkManagerMixin",


### PR DESCRIPTION
Also includes jojoe `int l = 1;` buffer thread optimization

All state outputs:
- `title` - The title screen has been loaded, this does not guarantee that it is currently on title screen, but at least that no world is generating or loading
- `waiting` - Appears just before the world starts generating and as soon as the player exits the world (disconnects)
- `generating,x` - The world is generating without a preview, x = loading percentage
- `previewing,x` - The world is generating with a preview, x = loading percentage
- `inworld,paused` - The world is loaded and the game is paused"
- `inworld,gamescreenopen` - The world is loaded, the game is not paused, and a gameplay related screen is opened (chat/inventory etc.)
- `inworld,unpaused` - The world is loaded, the game is not paused, and the mouse and keyboard control the player when the window is active